### PR TITLE
feat: implement normalization-based filter mapping with predefined ci…

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
-import { reverseFormatWorkArrangement, reverseFormatFilterValue } from '@/lib/filter-formatters'
+import { reverseFormatWorkArrangement, reverseFormatFilterValue, reverseFormatFilterValues } from '@/lib/filter-formatters'
 
 export async function GET(request: NextRequest) {
   try {
@@ -17,16 +17,18 @@ export async function GET(request: NextRequest) {
     const single = ['seniority', 'location', 'workArrangement', 'salaryMin', 'salaryMax']
     const multi = ['companyStage', 'productLifecycle', 'productDomain', 'managementScope', 'industryVertical', 'experienceBucket', 'domainExpertise']
 
-    // REVERSE MAPPING: Convert formatted display values back to database values
+    // REVERSE MAPPING: Convert formatted display values back to database values (array-based for accuracy)
     for (const key of single) {
       const v = searchParams.get(key)
       if (v) {
         if (key.includes('salary')) {
           filters[key] = parseInt(v)
         } else if (key === 'seniority') {
-          filters[key] = reverseFormatFilterValue(v, 'seniority')
+          // Seniority maps to array of possible DB values
+          filters[key] = reverseFormatFilterValues(v, 'seniority')
         } else if (key === 'location') {
-          filters[key] = reverseFormatFilterValue(v, 'location')
+          // Location maps to array of possible DB values
+          filters[key] = reverseFormatFilterValues(v, 'location')
         } else if (key === 'workArrangement') {
           // Work arrangement maps to array of possible DB values
           filters[key] = reverseFormatWorkArrangement(v)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,8 @@ import {
   filterValidLocations,
   formatFilterValue,
   reverseFormatWorkArrangement,
-  reverseFormatFilterValue
+  reverseFormatFilterValue,
+  reverseFormatFilterValues
 } from '@/lib/filter-formatters'
 
 // Lazy load the AdvancedFilterSidebar for better performance
@@ -547,14 +548,14 @@ export default function HomePage() {
             .order('created_at', { ascending: false })
             .range((page - 1) * limit, page * limit - 1)
 
-          // REVERSE MAPPING: Convert display values back to database values
+          // REVERSE MAPPING: Convert display values back to database values (array-based for accuracy)
           if (filters.seniority && filters.seniority.trim()) {
-            const dbValue = reverseFormatFilterValue(filters.seniority, 'seniority')
-            q = q.ilike('seniority_level', dbValue)
+            const dbValues = reverseFormatFilterValues(filters.seniority, 'seniority')
+            q = q.in('seniority_level', dbValues)
           }
           if (filters.location && filters.location.trim()) {
-            const dbValue = reverseFormatFilterValue(filters.location, 'location')
-            q = q.ilike('location_metro', dbValue)
+            const dbValues = reverseFormatFilterValues(filters.location, 'location')
+            q = q.in('location_metro', dbValues)
           }
           if (filters.workArrangement && filters.workArrangement.trim()) {
             // Work arrangement maps to multiple possible DB values
@@ -597,14 +598,14 @@ export default function HomePage() {
           .order('created_at', { ascending: false })
           .limit(filters.resultsPerPage || 50)
 
-        // REVERSE MAPPING: Convert display values back to database values
+        // REVERSE MAPPING: Convert display values back to database values (array-based for accuracy)
         if (filters.seniority && filters.seniority.trim()) {
-          const dbValue = reverseFormatFilterValue(filters.seniority, 'seniority')
-          query = query.ilike('seniority_level', dbValue)
+          const dbValues = reverseFormatFilterValues(filters.seniority, 'seniority')
+          query = query.in('seniority_level', dbValues)
         }
         if (filters.location && filters.location.trim()) {
-          const dbValue = reverseFormatFilterValue(filters.location, 'location')
-          query = query.ilike('location_metro', dbValue)
+          const dbValues = reverseFormatFilterValues(filters.location, 'location')
+          query = query.in('location_metro', dbValues)
         }
         if (filters.workArrangement && filters.workArrangement.trim()) {
           // Work arrangement maps to multiple possible DB values

--- a/src/lib/__tests__/filter-normalizers.test.ts
+++ b/src/lib/__tests__/filter-normalizers.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Test suite for filter normalizers
+ * Validates high-cardinality to low-cardinality normalization
+ */
+
+import {
+  normalizeSeniority,
+  normalizeLocation,
+  normalizeWorkArrangement,
+  PM_SENIORITY_LEVELS,
+  US_MAJOR_CITIES,
+  EU_MAJOR_CITIES,
+  getAllNormalizedCities,
+  reverseNormalizeSeniority,
+  reverseNormalizeLocation,
+  reverseFormatWorkArrangement
+} from '../filter-normalizers'
+
+// ==================== SENIORITY NORMALIZATION TESTS ====================
+
+console.log('=' .repeat(80))
+console.log('PM SENIORITY NORMALIZATION TESTS')
+console.log('=' .repeat(80))
+
+const seniorityTests = [
+  // Associate Product Manager
+  { input: 'apm', expected: 'Associate Product Manager' },
+  { input: 'associate', expected: 'Associate Product Manager' },
+  { input: 'junior', expected: 'Associate Product Manager' },
+  { input: 'entry level', expected: 'Associate Product Manager' },
+  { input: 'junior pm', expected: 'Associate Product Manager' },
+
+  // Product Manager
+  { input: 'pm', expected: 'Product Manager' },
+  { input: 'product manager', expected: 'Product Manager' },
+  { input: 'mid-level', expected: 'Product Manager' },
+  { input: 'intermediate', expected: 'Product Manager' },
+
+  // Senior Product Manager
+  { input: 'senior', expected: 'Senior Product Manager' },
+  { input: 'senior pm', expected: 'Senior Product Manager' },
+  { input: 'sr pm', expected: 'Senior Product Manager' },
+
+  // Lead Product Manager
+  { input: 'lead', expected: 'Lead Product Manager' },
+  { input: 'lead pm', expected: 'Lead Product Manager' },
+  { input: 'team lead', expected: 'Lead Product Manager' },
+
+  // Staff Product Manager
+  { input: 'staff', expected: 'Staff Product Manager' },
+  { input: 'staff pm', expected: 'Staff Product Manager' },
+  { input: 'principal', expected: 'Staff Product Manager' },
+  { input: 'principal pm', expected: 'Staff Product Manager' },
+
+  // Director
+  { input: 'director', expected: 'Director' },
+  { input: 'director of product', expected: 'Director' },
+  { input: 'group pm', expected: 'Director' },
+
+  // VP
+  { input: 'vp', expected: 'VP' },
+  { input: 'vice president', expected: 'VP' },
+  { input: 'vp product', expected: 'VP' },
+  { input: 'svp', expected: 'VP' },
+
+  // CPO
+  { input: 'cpo', expected: 'CPO' },
+  { input: 'chief product officer', expected: 'CPO' },
+  { input: 'head of product', expected: 'CPO' },
+]
+
+let seniorityPassed = 0
+let seniorityFailed = 0
+
+seniorityTests.forEach(({ input, expected }) => {
+  const result = normalizeSeniority(input)
+  const status = result === expected ? '✅' : '❌'
+  if (result === expected) {
+    seniorityPassed++
+  } else {
+    seniorityFailed++
+    console.log(`${status} "${input}" → "${result}" (expected: "${expected}")`)
+  }
+})
+
+console.log(`\nResults: ${seniorityPassed}/${seniorityTests.length} passed`)
+if (seniorityFailed === 0) {
+  console.log('✅ All seniority normalization tests passed!')
+}
+
+console.log('\nStandard PM Seniority Levels (8 levels):')
+PM_SENIORITY_LEVELS.forEach((level, i) => {
+  console.log(`  ${i + 1}. ${level}`)
+})
+
+// ==================== LOCATION NORMALIZATION TESTS ====================
+
+console.log('\n' + '='.repeat(80))
+console.log('LOCATION NORMALIZATION TESTS')
+console.log('=' .repeat(80))
+
+const locationTests = [
+  // Remote
+  { input: 'remote', expected: 'Remote' },
+  { input: 'remote - us', expected: 'Remote' },
+  { input: 'fully remote', expected: 'Remote' },
+  { input: 'wfh', expected: 'Remote' },
+
+  // New York
+  { input: 'nyc', expected: 'New York' },
+  { input: 'new york', expected: 'New York' },
+  { input: 'new york city', expected: 'New York' },
+  { input: 'manhattan', expected: 'New York' },
+  { input: 'brooklyn', expected: 'New York' },
+
+  // San Francisco
+  { input: 'sf', expected: 'San Francisco' },
+  { input: 'san francisco', expected: 'San Francisco' },
+  { input: 'sf bay area', expected: 'San Francisco' },
+  { input: 'bay area', expected: 'San Francisco' },
+  { input: 'silicon valley', expected: 'San Francisco' },
+  { input: 'palo alto', expected: 'San Francisco' },
+  { input: 'mountain view', expected: 'San Francisco' },
+
+  // Other US cities
+  { input: 'seattle', expected: 'Seattle' },
+  { input: 'austin', expected: 'Austin' },
+  { input: 'boston', expected: 'Boston' },
+  { input: 'chicago', expected: 'Chicago' },
+  { input: 'denver', expected: 'Denver' },
+  { input: 'los angeles', expected: 'Los Angeles' },
+  { input: 'la', expected: 'Los Angeles' },
+  { input: 'washington dc', expected: 'Washington DC' },
+  { input: 'dc', expected: 'Washington DC' },
+
+  // EU cities
+  { input: 'london', expected: 'London' },
+  { input: 'berlin', expected: 'Berlin' },
+  { input: 'paris', expected: 'Paris' },
+  { input: 'amsterdam', expected: 'Amsterdam' },
+  { input: 'dublin', expected: 'Dublin' },
+  { input: 'madrid', expected: 'Madrid' },
+  { input: 'barcelona', expected: 'Barcelona' },
+
+  // Invalid - should return null
+  { input: 'null', expected: null },
+  { input: 'n/a', expected: null },
+  { input: 'unknown', expected: null },
+  { input: '', expected: null },
+]
+
+let locationPassed = 0
+let locationFailed = 0
+
+locationTests.forEach(({ input, expected }) => {
+  const result = normalizeLocation(input)
+  const status = result === expected ? '✅' : '❌'
+  if (result === expected) {
+    locationPassed++
+  } else {
+    locationFailed++
+    console.log(`${status} "${input}" → "${result}" (expected: "${expected}")`)
+  }
+})
+
+console.log(`\nResults: ${locationPassed}/${locationTests.length} passed`)
+if (locationFailed === 0) {
+  console.log('✅ All location normalization tests passed!')
+}
+
+console.log(`\nTotal Normalized Cities: ${getAllNormalizedCities().length}`)
+console.log(`  US Cities (500K+): ${US_MAJOR_CITIES.length}`)
+console.log(`  EU Cities (500K+): ${EU_MAJOR_CITIES.length}`)
+console.log(`  Plus: Remote`)
+
+// ==================== WORK ARRANGEMENT TESTS ====================
+
+console.log('\n' + '='.repeat(80))
+console.log('WORK ARRANGEMENT NORMALIZATION TESTS (KEEPING - WORKING)')
+console.log('=' .repeat(80))
+
+const workTests = [
+  { input: 'remote', expected: 'Remote' },
+  { input: 'remote_us', expected: 'Remote' },
+  { input: 'wfh', expected: 'Remote' },
+  { input: 'hybrid', expected: 'Hybrid' },
+  { input: 'flexible', expected: 'Hybrid' },
+  { input: 'onsite', expected: 'In-Person' },
+  { input: 'office', expected: 'In-Person' },
+]
+
+let workPassed = 0
+workTests.forEach(({ input, expected }) => {
+  const result = normalizeWorkArrangement(input)
+  if (result === expected) workPassed++
+  else console.log(`❌ "${input}" → "${result}" (expected: "${expected}")`)
+})
+
+console.log(`Results: ${workPassed}/${workTests.length} passed`)
+if (workPassed === workTests.length) {
+  console.log('✅ All work arrangement tests passed!')
+}
+
+// ==================== REVERSE MAPPING TESTS ====================
+
+console.log('\n' + '='.repeat(80))
+console.log('REVERSE MAPPING TESTS')
+console.log('=' .repeat(80))
+
+console.log('\nSeniority Reverse Mapping:')
+const seniorityReversalTests = [
+  'Associate Product Manager',
+  'Product Manager',
+  'Senior Product Manager',
+  'Lead Product Manager',
+  'Staff Product Manager',
+  'Director',
+  'VP',
+  'CPO'
+]
+
+seniorityReversalTests.forEach(level => {
+  const dbValues = reverseNormalizeSeniority(level as any)
+  console.log(`  "${level}" → ${dbValues.length} DB values: [${dbValues.slice(0, 3).join(', ')}...]`)
+})
+
+console.log('\nLocation Reverse Mapping (samples):')
+const locationReversalTests = ['New York', 'San Francisco', 'Remote', 'London']
+
+locationReversalTests.forEach(city => {
+  const dbValues = reverseNormalizeLocation(city)
+  console.log(`  "${city}" → ${dbValues.length} DB values: [${dbValues.slice(0, 3).join(', ')}...]`)
+})
+
+console.log('\nWork Arrangement Reverse Mapping:')
+const workReversalTests = ['Remote', 'Hybrid', 'In-Person']
+
+workReversalTests.forEach(work => {
+  const dbValues = reverseFormatWorkArrangement(work)
+  console.log(`  "${work}" → ${dbValues.length} DB values: [${dbValues.slice(0, 3).join(', ')}...]`)
+})
+
+// ==================== CARDINALITY REDUCTION SUMMARY ====================
+
+console.log('\n' + '='.repeat(80))
+console.log('CARDINALITY REDUCTION SUMMARY')
+console.log('=' .repeat(80))
+
+console.log(`
+✅ Seniority:
+   High Cardinality (Input): 60+ variations
+   Low Cardinality (Output): 8 standard PM levels
+   Reduction: ${((1 - 8/60) * 100).toFixed(0)}%
+
+✅ Locations:
+   High Cardinality (Input): 1000+ variations
+   Low Cardinality (Output): ${getAllNormalizedCities().length} major cities
+   Reduction: ${((1 - getAllNormalizedCities().length/1000) * 100).toFixed(0)}%
+
+✅ Work Arrangement:
+   High Cardinality (Input): 30+ variations
+   Low Cardinality (Output): 3 options
+   Reduction: 90%
+`)
+
+console.log('=' .repeat(80))
+console.log('FINAL SUMMARY')
+console.log('=' .repeat(80))
+console.log(`✅ Seniority: ${seniorityPassed}/${seniorityTests.length} tests passed`)
+console.log(`✅ Location: ${locationPassed}/${locationTests.length} tests passed`)
+console.log(`✅ Work Arrangement: ${workPassed}/${workTests.length} tests passed`)
+console.log(`✅ Total: ${seniorityPassed + locationPassed + workPassed}/${seniorityTests.length + locationTests.length + workTests.length} tests passed`)
+console.log('=' .repeat(80))

--- a/src/lib/filter-formatters.ts
+++ b/src/lib/filter-formatters.ts
@@ -1,442 +1,71 @@
 /**
  * Filter Value Formatting Utilities
- * Formats raw database values for user-friendly display and handles reverse mapping for queries
+ * Delegates to normalizers for seniority and location
+ * Keeps work arrangement logic (working as expected)
  */
 
 import { formatCamelCase } from './text-formatter'
+import {
+  normalizeSeniority,
+  normalizeLocation,
+  normalizeWorkArrangement as normalizeWork,
+  reverseNormalizeSeniority,
+  reverseNormalizeLocation,
+  reverseFormatWorkArrangement as reverseWorkArr,
+  PM_SENIORITY_LEVELS,
+  getAllNormalizedCities,
+  isValidLocation
+} from './filter-normalizers'
+
+// Re-export for compatibility
+export { normalizeWorkArrangement } from './filter-normalizers'
 
 // ==================== SENIORITY LEVEL FORMATTING ====================
 
 /**
- * Comprehensive seniority level mapping
- * Maps all possible variations to standardized display values
- */
-const SENIORITY_MAP: Record<string, string> = {
-  // Entry level variations
-  'entry': 'Entry Level',
-  'entry-level': 'Entry Level',
-  'entry level': 'Entry Level',
-  'junior': 'Junior',
-  'jr': 'Junior',
-  'associate': 'Associate',
-  'early_career': 'Entry Level',
-
-  // Mid level variations
-  'mid': 'Mid-Level',
-  'mid-level': 'Mid-Level',
-  'mid level': 'Mid-Level',
-  'intermediate': 'Mid-Level',
-
-  // Senior variations
-  'senior': 'Senior',
-  'sr': 'Senior',
-  'senior level': 'Senior',
-  'senior-level': 'Senior',
-
-  // Staff/Principal variations
-  'staff': 'Staff',
-  'principal': 'Principal',
-  'lead': 'Lead',
-  'senior staff': 'Senior Staff',
-  'staff engineer': 'Staff',
-  'principal pm': 'Principal',
-
-  // Management variations
-  'manager': 'Manager',
-  'senior manager': 'Senior Manager',
-  'director': 'Director',
-  'senior director': 'Senior Director',
-  'vp': 'VP',
-  'vice president': 'VP',
-  'svp': 'Senior VP',
-  'senior vp': 'Senior VP',
-  'evp': 'Executive VP',
-  'executive vp': 'Executive VP',
-
-  // C-level variations
-  'c-level': 'C-Level',
-  'c level': 'C-Level',
-  'executive': 'Executive',
-  'cpo': 'C-Level',
-  'cto': 'C-Level',
-  'ceo': 'C-Level',
-
-  // IC variations
-  'ic': 'Individual Contributor',
-  'individual contributor': 'Individual Contributor',
-  'individual_contributor': 'Individual Contributor',
-}
-
-/**
- * Format seniority level to Title Case with comprehensive mapping
+ * Format seniority level using normalization
+ * Maps to 8 PM-specific levels
  */
 export function formatSeniorityLevel(value: string): string {
   if (!value) return ''
-
-  const lowerValue = value.toLowerCase().trim()
-  return SENIORITY_MAP[lowerValue] || formatCamelCase(value)
+  const normalized = normalizeSeniority(value)
+  return normalized || formatCamelCase(value)
 }
 
 /**
- * Get all unique standardized seniority levels in display order
+ * Get standardized PM seniority levels (8 levels)
  */
 export function getStandardSeniorityLevels(): string[] {
-  return [
-    'Entry Level',
-    'Junior',
-    'Associate',
-    'Mid-Level',
-    'Senior',
-    'Staff',
-    'Lead',
-    'Principal',
-    'Senior Staff',
-    'Manager',
-    'Senior Manager',
-    'Director',
-    'Senior Director',
-    'VP',
-    'Senior VP',
-    'Executive VP',
-    'C-Level',
-    'Individual Contributor'
-  ]
+  return [...PM_SENIORITY_LEVELS]
 }
 
 // ==================== LOCATION FORMATTING ====================
 
 /**
- * Invalid location markers to filter out
- */
-const INVALID_LOCATIONS = [
-  'null', 'none', 'n/a', 'unknown', 'tbd', 'to be determined',
-  'various', 'multiple', 'flexible', 'anywhere', 'worldwide',
-  '', 'not specified', 'unspecified', 'na', 'n.a.'
-]
-
-/**
- * Comprehensive location mapping for USA and EU cities/metros
- */
-const LOCATION_MAP: Record<string, string> = {
-  // Remote
-  'remote': 'Remote',
-  'remote - us': 'Remote (US)',
-  'remote - usa': 'Remote (US)',
-  'remote - united states': 'Remote (US)',
-  'remote (us)': 'Remote (US)',
-  'remote (usa)': 'Remote (US)',
-  'remote - eu': 'Remote (EU)',
-  'remote - europe': 'Remote (EU)',
-  'remote (eu)': 'Remote (EU)',
-  'remote - global': 'Remote (Global)',
-  'remote (global)': 'Remote (Global)',
-  'fully remote': 'Remote',
-  'work from home': 'Remote',
-  'wfh': 'Remote',
-
-  // USA - Major Tech Hubs
-  'sf': 'San Francisco',
-  'san francisco': 'San Francisco',
-  'sf bay area': 'San Francisco Bay Area',
-  'san francisco bay area': 'San Francisco Bay Area',
-  'bay area': 'San Francisco Bay Area',
-  'silicon valley': 'San Francisco Bay Area',
-
-  'nyc': 'New York City',
-  'new york': 'New York City',  // Priority: map to city not state
-  'new york city': 'New York City',
-  'new york, ny': 'New York City',
-  'manhattan': 'New York City',
-  'brooklyn': 'New York City',
-
-  'seattle': 'Seattle',
-  'seattle, wa': 'Seattle',
-
-  'austin': 'Austin',
-  'austin, tx': 'Austin',
-
-  'boston': 'Boston',
-  'boston, ma': 'Boston',
-
-  'los angeles': 'Los Angeles',
-  'la': 'Los Angeles',
-  'los angeles, ca': 'Los Angeles',
-
-  // USA - Other Major Cities
-  'chicago': 'Chicago',
-  'chicago, il': 'Chicago',
-
-  'denver': 'Denver',
-  'denver, co': 'Denver',
-
-  'portland': 'Portland',
-  'portland, or': 'Portland',
-
-  'washington dc': 'Washington DC',
-  'washington, dc': 'Washington DC',
-  'dc': 'Washington DC',
-
-  'atlanta': 'Atlanta',
-  'atlanta, ga': 'Atlanta',
-
-  'miami': 'Miami',
-  'miami, fl': 'Miami',
-
-  'dallas': 'Dallas',
-  'dallas, tx': 'Dallas',
-
-  'houston': 'Houston',
-  'houston, tx': 'Houston',
-
-  'philadelphia': 'Philadelphia',
-  'philadelphia, pa': 'Philadelphia',
-
-  'phoenix': 'Phoenix',
-  'phoenix, az': 'Phoenix',
-
-  'san diego': 'San Diego',
-  'san diego, ca': 'San Diego',
-
-  'raleigh': 'Raleigh',
-  'raleigh, nc': 'Raleigh',
-  'research triangle': 'Raleigh-Durham',
-
-  'nashville': 'Nashville',
-  'nashville, tn': 'Nashville',
-
-  'salt lake city': 'Salt Lake City',
-  'slc': 'Salt Lake City',
-
-  'minneapolis': 'Minneapolis',
-  'minneapolis, mn': 'Minneapolis',
-
-  // USA - States
-  'california': 'California',
-  'ca': 'California',
-  'texas': 'Texas',
-  'tx': 'Texas',
-  'new york state': 'New York',
-  'ny state': 'New York',
-  'washington': 'Washington',
-  'wa': 'Washington',
-  'massachusetts': 'Massachusetts',
-  'ma': 'Massachusetts',
-  'colorado': 'Colorado',
-  'co': 'Colorado',
-
-  // USA - Regions
-  'usa': 'USA',
-  'us': 'USA',
-  'united states': 'USA',
-
-  // EU - Major Cities
-  'london': 'London',
-  'london, uk': 'London',
-
-  'berlin': 'Berlin',
-  'berlin, germany': 'Berlin',
-
-  'paris': 'Paris',
-  'paris, france': 'Paris',
-
-  'amsterdam': 'Amsterdam',
-  'amsterdam, netherlands': 'Amsterdam',
-
-  'dublin': 'Dublin',
-  'dublin, ireland': 'Dublin',
-
-  'madrid': 'Madrid',
-  'madrid, spain': 'Madrid',
-
-  'barcelona': 'Barcelona',
-  'barcelona, spain': 'Barcelona',
-
-  'munich': 'Munich',
-  'munich, germany': 'Munich',
-
-  'stockholm': 'Stockholm',
-  'stockholm, sweden': 'Stockholm',
-
-  'copenhagen': 'Copenhagen',
-  'copenhagen, denmark': 'Copenhagen',
-
-  'zurich': 'Zurich',
-  'zurich, switzerland': 'Zurich',
-
-  'vienna': 'Vienna',
-  'vienna, austria': 'Vienna',
-
-  'prague': 'Prague',
-  'prague, czech republic': 'Prague',
-
-  'warsaw': 'Warsaw',
-  'warsaw, poland': 'Warsaw',
-
-  // EU - Countries
-  'uk': 'United Kingdom',
-  'united kingdom': 'United Kingdom',
-  'germany': 'Germany',
-  'france': 'France',
-  'netherlands': 'Netherlands',
-  'ireland': 'Ireland',
-  'spain': 'Spain',
-  'sweden': 'Sweden',
-  'denmark': 'Denmark',
-  'switzerland': 'Switzerland',
-  'austria': 'Austria',
-  'belgium': 'Belgium',
-  'portugal': 'Portugal',
-  'italy': 'Italy',
-
-  // EU - Region
-  'europe': 'Europe',
-  'eu': 'Europe',
-  'european union': 'Europe',
-
-  // Canada
-  'toronto': 'Toronto',
-  'toronto, canada': 'Toronto',
-  'vancouver': 'Vancouver',
-  'vancouver, canada': 'Vancouver',
-  'montreal': 'Montreal',
-  'montreal, canada': 'Montreal',
-  'canada': 'Canada',
-
-  // Australia
-  'sydney': 'Sydney',
-  'melbourne': 'Melbourne',
-  'australia': 'Australia',
-}
-
-/**
  * Filter out invalid location values
  */
 export function filterValidLocations(locations: string[]): string[] {
-  return locations.filter(loc => {
-    if (!loc) return false
-
-    const lowerLoc = loc.toLowerCase().trim()
-
-    // Exclude invalid markers
-    if (INVALID_LOCATIONS.includes(lowerLoc)) return false
-
-    // Exclude very short values (likely invalid)
-    if (lowerLoc.length < 2) return false
-
-    // Exclude numeric-only values
-    if (/^\d+$/.test(lowerLoc)) return false
-
-    // Exclude values that look like job titles or other non-location data
-    if (lowerLoc.includes('product manager') || lowerLoc.includes('engineer')) return false
-
-    return true
-  })
+  return locations.filter(isValidLocation)
 }
 
 /**
- * Format location to proper display format
+ * Format location using normalization
+ * Maps to major US/EU cities (500K+)
  */
 export function formatLocation(value: string): string {
   if (!value) return ''
+  const normalized = normalizeLocation(value)
+  return normalized || formatCamelCase(value)
+}
 
-  const lowerValue = value.toLowerCase().trim()
-
-  // Check mapping first
-  if (LOCATION_MAP[lowerValue]) {
-    return LOCATION_MAP[lowerValue]
-  }
-
-  // If not in map, apply generic formatting
-  return formatCamelCase(value)
+/**
+ * Get all normalized cities for dropdown
+ */
+export function getAllCities(): string[] {
+  return getAllNormalizedCities()
 }
 
 // ==================== WORK ARRANGEMENT FORMATTING ====================
-
-/**
- * Comprehensive work arrangement mapping
- * ALL variations map to exactly one of: Remote, Hybrid, In-Person
- */
-const WORK_ARRANGEMENT_MAP: Record<string, 'Remote' | 'Hybrid' | 'In-Person' | null> = {
-  // Remote variations
-  'remote': 'Remote',
-  'remote_us': 'Remote',
-  'remote_only': 'Remote',
-  'remote_first': 'Remote',
-  'remote_global': 'Remote',
-  'fully_remote': 'Remote',
-  'fully remote': 'Remote',
-  'work_from_home': 'Remote',
-  'work from home': 'Remote',
-  'wfh': 'Remote',
-  '100% remote': 'Remote',
-  'remote work': 'Remote',
-  'remote (us)': 'Remote',
-  'remote (global)': 'Remote',
-
-  // Hybrid variations
-  'hybrid': 'Hybrid',
-  'hybrid_only': 'Hybrid',
-  'flexible': 'Hybrid',
-  'flexible_remote': 'Hybrid',
-  'part_remote': 'Hybrid',
-  'remote_hybrid': 'Hybrid',
-  'hybrid remote': 'Hybrid',
-  'flexible work': 'Hybrid',
-  'hybrid work': 'Hybrid',
-  'hybrid/remote': 'Hybrid',
-  'remote/hybrid': 'Hybrid',
-  'part-time remote': 'Hybrid',
-  'partially remote': 'Hybrid',
-
-  // In-Person variations
-  'onsite': 'In-Person',
-  'on-site': 'In-Person',
-  'on site': 'In-Person',
-  'onsite_only': 'In-Person',
-  'office_first': 'In-Person',
-  'office first': 'In-Person',
-  'in-person': 'In-Person',
-  'in-office': 'In-Person',
-  'in_person': 'In-Person',
-  'in_office': 'In-Person',
-  'office': 'In-Person',
-  'in office': 'In-Person',
-  'on-site work': 'In-Person',
-  'onsite work': 'In-Person',
-  '100% onsite': 'In-Person',
-  '100% on-site': 'In-Person',
-  'full-time office': 'In-Person',
-}
-
-/**
- * Normalize work arrangement to one of 3 standard values
- * Returns null for unmappable values (they will be filtered out)
- */
-export function normalizeWorkArrangement(value: string): string | null {
-  if (!value) return null
-
-  const lowerValue = value.toLowerCase().trim()
-
-  // Check exact mapping first
-  const mapped = WORK_ARRANGEMENT_MAP[lowerValue]
-  if (mapped !== undefined) {
-    return mapped
-  }
-
-  // Try pattern matching as fallback
-  if (lowerValue.includes('remote') && !lowerValue.includes('hybrid')) {
-    return 'Remote'
-  }
-  if (lowerValue.includes('hybrid') || lowerValue.includes('flexible')) {
-    return 'Hybrid'
-  }
-  if (lowerValue.includes('onsite') || lowerValue.includes('office') || lowerValue.includes('on-site')) {
-    return 'In-Person'
-  }
-
-  // Unable to map - return null to filter out
-  return null
-}
 
 /**
  * Get the 3 standard work arrangement options
@@ -445,67 +74,45 @@ export function getStandardWorkArrangements(): string[] {
   return ['Remote', 'Hybrid', 'In-Person']
 }
 
+// Note: normalizeWorkArrangement is imported from filter-normalizers
+
 // ==================== REVERSE MAPPING FOR QUERIES ====================
 
 /**
  * Convert display value back to database values for work arrangement queries
- * Returns array of possible database values that map to this display value
  */
 export function reverseFormatWorkArrangement(displayValue: string): string[] {
-  const reverseMap: Record<string, string[]> = {
-    'Remote': [
-      'remote', 'remote_us', 'remote_only', 'remote_first', 'remote_global',
-      'fully_remote', 'fully remote', 'work_from_home', 'work from home', 'wfh',
-      '100% remote', 'remote work', 'remote (us)', 'remote (global)'
-    ],
-    'Hybrid': [
-      'hybrid', 'hybrid_only', 'flexible', 'flexible_remote', 'part_remote',
-      'remote_hybrid', 'hybrid remote', 'flexible work', 'hybrid work',
-      'hybrid/remote', 'remote/hybrid', 'part-time remote', 'partially remote'
-    ],
-    'In-Person': [
-      'onsite', 'on-site', 'on site', 'onsite_only', 'office_first', 'office first',
-      'in-person', 'in-office', 'in_person', 'in_office', 'office', 'in office',
-      'on-site work', 'onsite work', '100% onsite', '100% on-site', 'full-time office'
-    ]
-  }
-
-  return reverseMap[displayValue] || [displayValue.toLowerCase()]
+  return reverseWorkArr(displayValue)
 }
 
 /**
- * Convert formatted display value back to database format for queries
- * Handles seniority and other single-value filters
+ * Convert formatted display value back to database values (array) for queries
+ * Returns array of possible database values for accurate filtering
+ */
+export function reverseFormatFilterValues(displayValue: string, filterType?: string): string[] {
+  if (!displayValue) return []
+
+  // For seniority, use reverse normalization (returns all possible DB values)
+  if (filterType === 'seniority') {
+    return reverseNormalizeSeniority(displayValue as any)
+  }
+
+  // For locations, use reverse normalization (returns all possible DB values)
+  if (filterType === 'location') {
+    return reverseNormalizeLocation(displayValue)
+  }
+
+  // Generic fallback
+  return [displayValue.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_-]/g, '')]
+}
+
+/**
+ * Convert formatted display value back to single database value (legacy)
+ * Use reverseFormatFilterValues for better accuracy
  */
 export function reverseFormatFilterValue(displayValue: string, filterType?: string): string {
-  if (!displayValue) return ''
-
-  // For seniority, find the original key from the map
-  if (filterType === 'seniority') {
-    const lowerDisplay = displayValue.toLowerCase()
-    // Find first matching key in the seniority map
-    for (const [key, value] of Object.entries(SENIORITY_MAP)) {
-      if (value.toLowerCase() === lowerDisplay) {
-        return key
-      }
-    }
-  }
-
-  // For locations, find the original key from the map
-  if (filterType === 'location') {
-    const lowerDisplay = displayValue.toLowerCase()
-    for (const [key, value] of Object.entries(LOCATION_MAP)) {
-      if (value.toLowerCase() === lowerDisplay) {
-        return key
-      }
-    }
-  }
-
-  // Generic fallback: convert to lowercase with underscores
-  return displayValue
-    .toLowerCase()
-    .replace(/\s+/g, '_')
-    .replace(/[^a-z0-9_-]/g, '')
+  const values = reverseFormatFilterValues(displayValue, filterType)
+  return values[0] || displayValue.toLowerCase()
 }
 
 // ==================== GENERIC FORMATTER ====================
@@ -526,10 +133,9 @@ export function formatFilterValue(value: string, filterType?: string): string {
       return formatLocation(value)
 
     case 'workArrangement':
-      return normalizeWorkArrangement(value) || ''
+      return normalizeWork(value) || ''
 
     default:
-      // Use generic CamelCase formatter for other fields
       return formatCamelCase(value)
   }
 }

--- a/src/lib/filter-normalizers.ts
+++ b/src/lib/filter-normalizers.ts
@@ -1,0 +1,694 @@
+/**
+ * Filter Value Normalization - High Cardinality to Low Cardinality
+ *
+ * This file contains predefined normalization tables for:
+ * - US Cities (500K+ population)
+ * - EU Cities (500K+ population)
+ * - Product Manager Seniority Levels (8 standard levels)
+ *
+ * Goal: Accurately reduce high-cardinality input to standardized low-cardinality output
+ */
+
+import { formatCamelCase } from './text-formatter'
+
+// ==================== SENIORITY NORMALIZATION ====================
+
+/**
+ * Product Manager Seniority Levels (8 Standard Levels)
+ * Ordered by career progression
+ */
+export const PM_SENIORITY_LEVELS = [
+  'Associate Product Manager',
+  'Product Manager',
+  'Senior Product Manager',
+  'Lead Product Manager',
+  'Staff Product Manager',
+  'Director',
+  'VP',
+  'CPO'
+] as const
+
+export type PMSeniorityLevel = typeof PM_SENIORITY_LEVELS[number]
+
+/**
+ * Comprehensive mapping: input variations → standardized seniority level
+ * Maps ALL possible variations to exactly 8 levels
+ */
+const SENIORITY_NORMALIZATION_MAP: Record<string, PMSeniorityLevel> = {
+  // Associate Product Manager
+  'apm': 'Associate Product Manager',
+  'associate': 'Associate Product Manager',
+  'associate pm': 'Associate Product Manager',
+  'associate product manager': 'Associate Product Manager',
+  'junior': 'Associate Product Manager',
+  'junior pm': 'Associate Product Manager',
+  'junior product manager': 'Associate Product Manager',
+  'entry': 'Associate Product Manager',
+  'entry level': 'Associate Product Manager',
+  'entry-level': 'Associate Product Manager',
+  'entry level pm': 'Associate Product Manager',
+  'jr': 'Associate Product Manager',
+  'jr pm': 'Associate Product Manager',
+  'early career': 'Associate Product Manager',
+
+  // Product Manager (Mid-level)
+  'pm': 'Product Manager',
+  'product manager': 'Product Manager',
+  'mid': 'Product Manager',
+  'mid-level': 'Product Manager',
+  'mid level': 'Product Manager',
+  'mid-level pm': 'Product Manager',
+  'intermediate': 'Product Manager',
+  'intermediate pm': 'Product Manager',
+
+  // Senior Product Manager
+  'senior': 'Senior Product Manager',
+  'senior pm': 'Senior Product Manager',
+  'senior product manager': 'Senior Product Manager',
+  'sr': 'Senior Product Manager',
+  'sr pm': 'Senior Product Manager',
+  'sr product manager': 'Senior Product Manager',
+  'senior level': 'Senior Product Manager',
+
+  // Lead Product Manager
+  'lead': 'Lead Product Manager',
+  'lead pm': 'Lead Product Manager',
+  'lead product manager': 'Lead Product Manager',
+  'team lead': 'Lead Product Manager',
+  'product lead': 'Lead Product Manager',
+
+  // Staff Product Manager
+  'staff': 'Staff Product Manager',
+  'staff pm': 'Staff Product Manager',
+  'staff product manager': 'Staff Product Manager',
+  'principal': 'Staff Product Manager',
+  'principal pm': 'Staff Product Manager',
+  'principal product manager': 'Staff Product Manager',
+
+  // Director
+  'director': 'Director',
+  'director of product': 'Director',
+  'director product': 'Director',
+  'product director': 'Director',
+  'senior director': 'Director',
+  'group pm': 'Director',
+  'group product manager': 'Director',
+
+  // VP
+  'vp': 'VP',
+  'vice president': 'VP',
+  'vp product': 'VP',
+  'vp of product': 'VP',
+  'vice president of product': 'VP',
+  'svp': 'VP',
+  'senior vp': 'VP',
+  'senior vice president': 'VP',
+  'evp': 'VP',
+  'executive vp': 'VP',
+
+  // CPO
+  'cpo': 'CPO',
+  'chief product officer': 'CPO',
+  'head of product': 'CPO',
+  'c-level': 'CPO',
+  'executive': 'CPO',
+}
+
+/**
+ * Normalize seniority input to one of 8 standard PM levels
+ */
+export function normalizeSeniority(input: string): PMSeniorityLevel | null {
+  if (!input) return null
+
+  const normalized = input.toLowerCase().trim()
+
+  // Direct mapping
+  if (normalized in SENIORITY_NORMALIZATION_MAP) {
+    return SENIORITY_NORMALIZATION_MAP[normalized]
+  }
+
+  // Pattern matching for variations
+  if (normalized.includes('associate') || normalized.includes('junior') || normalized.includes('entry')) {
+    return 'Associate Product Manager'
+  }
+  if (normalized.includes('staff') || normalized.includes('principal')) {
+    return 'Staff Product Manager'
+  }
+  if (normalized.includes('lead') && !normalized.includes('director')) {
+    return 'Lead Product Manager'
+  }
+  if (normalized.includes('director') || normalized.includes('group pm')) {
+    return 'Director'
+  }
+  if (normalized.includes('vp') || normalized.includes('vice president')) {
+    return 'VP'
+  }
+  if (normalized.includes('cpo') || normalized.includes('chief') || normalized.includes('head of product')) {
+    return 'CPO'
+  }
+  if (normalized.includes('senior') || normalized.includes('sr')) {
+    return 'Senior Product Manager'
+  }
+
+  // Default to Product Manager for mid-level variations
+  if (normalized.includes('product manager') || normalized.includes('pm')) {
+    return 'Product Manager'
+  }
+
+  return null // Unknown seniority
+}
+
+// ==================== LOCATION NORMALIZATION ====================
+
+/**
+ * Major US Cities (500K+ population)
+ * Source: US Census Bureau
+ */
+export const US_MAJOR_CITIES = [
+  // 1M+
+  'New York',
+  'Los Angeles',
+  'Chicago',
+  'Houston',
+  'Phoenix',
+  'Philadelphia',
+  'San Antonio',
+  'San Diego',
+  'Dallas',
+  'San Jose',
+
+  // 500K - 1M
+  'Austin',
+  'Jacksonville',
+  'Fort Worth',
+  'Columbus',
+  'Charlotte',
+  'San Francisco',
+  'Indianapolis',
+  'Seattle',
+  'Denver',
+  'Washington DC',
+  'Boston',
+  'El Paso',
+  'Nashville',
+  'Detroit',
+  'Oklahoma City',
+  'Portland',
+  'Las Vegas',
+  'Memphis',
+  'Louisville',
+  'Baltimore',
+  'Milwaukee',
+  'Albuquerque',
+  'Tucson',
+  'Fresno',
+  'Sacramento',
+  'Kansas City',
+  'Mesa',
+  'Atlanta',
+  'Omaha',
+  'Colorado Springs',
+  'Raleigh',
+  'Miami',
+  'Long Beach',
+  'Virginia Beach',
+  'Oakland',
+  'Minneapolis',
+  'Tulsa',
+  'Tampa',
+  'Arlington',
+  'New Orleans',
+] as const
+
+/**
+ * Major EU Cities (500K+ population)
+ * Source: Eurostat, National Statistics Agencies
+ */
+export const EU_MAJOR_CITIES = [
+  // Western Europe
+  'London',
+  'Berlin',
+  'Madrid',
+  'Rome',
+  'Paris',
+  'Barcelona',
+  'Vienna',
+  'Hamburg',
+  'Munich',
+  'Milan',
+
+  // Central/Eastern Europe
+  'Warsaw',
+  'Budapest',
+  'Prague',
+  'Bucharest',
+  'Sofia',
+
+  // Northern Europe
+  'Stockholm',
+  'Copenhagen',
+  'Helsinki',
+  'Oslo',
+  'Amsterdam',
+  'Rotterdam',
+  'Brussels',
+
+  // Southern Europe
+  'Athens',
+  'Lisbon',
+  'Valencia',
+  'Seville',
+  'Naples',
+  'Marseille',
+
+  // Other major tech hubs
+  'Dublin',
+  'Lyon',
+  'Toulouse',
+  'Frankfurt',
+  'Cologne',
+  'Stuttgart',
+  'Dortmund',
+  'Essen',
+  'Dresden',
+  'Antwerp',
+  'Gothenburg',
+  'Krakow',
+  'Wroclaw',
+  'Porto',
+] as const
+
+/**
+ * Comprehensive location normalization mapping
+ * Maps variations → standardized city names
+ */
+const LOCATION_NORMALIZATION_MAP: Record<string, string> = {
+  // Remote
+  'remote': 'Remote',
+  'remote - us': 'Remote',
+  'remote us': 'Remote',
+  'remote - usa': 'Remote',
+  'remote usa': 'Remote',
+  'remote - global': 'Remote',
+  'remote global': 'Remote',
+  'fully remote': 'Remote',
+  'work from home': 'Remote',
+  'wfh': 'Remote',
+
+  // New York Metro
+  'nyc': 'New York',
+  'new york': 'New York',
+  'new york city': 'New York',
+  'new york, ny': 'New York',
+  'manhattan': 'New York',
+  'brooklyn': 'New York',
+  'queens': 'New York',
+  'bronx': 'New York',
+  'staten island': 'New York',
+  'ny': 'New York',
+
+  // San Francisco Bay Area
+  'sf': 'San Francisco',
+  'san francisco': 'San Francisco',
+  'sf bay area': 'San Francisco',
+  'san francisco bay area': 'San Francisco',
+  'bay area': 'San Francisco',
+  'silicon valley': 'San Francisco',
+  'palo alto': 'San Francisco',
+  'mountain view': 'San Francisco',
+  'sunnyvale': 'San Francisco',
+  'cupertino': 'San Francisco',
+  'santa clara': 'San Francisco',
+  'menlo park': 'San Francisco',
+  'redwood city': 'San Francisco',
+
+  // Los Angeles Metro
+  'la': 'Los Angeles',
+  'los angeles': 'Los Angeles',
+  'los angeles, ca': 'Los Angeles',
+  'santa monica': 'Los Angeles',
+  'venice': 'Los Angeles',
+  'hollywood': 'Los Angeles',
+
+  // Seattle
+  'seattle': 'Seattle',
+  'seattle, wa': 'Seattle',
+  'bellevue': 'Seattle',
+  'redmond': 'Seattle',
+
+  // Austin
+  'austin': 'Austin',
+  'austin, tx': 'Austin',
+
+  // Boston
+  'boston': 'Boston',
+  'boston, ma': 'Boston',
+  'cambridge': 'Boston',
+  'somerville': 'Boston',
+
+  // Chicago
+  'chicago': 'Chicago',
+  'chicago, il': 'Chicago',
+
+  // Denver
+  'denver': 'Denver',
+  'denver, co': 'Denver',
+  'boulder': 'Denver',
+
+  // Washington DC
+  'dc': 'Washington DC',
+  'washington': 'Washington DC',
+  'washington dc': 'Washington DC',
+  'washington, dc': 'Washington DC',
+  'arlington': 'Washington DC',
+  'alexandria': 'Washington DC',
+
+  // Portland
+  'portland': 'Portland',
+  'portland, or': 'Portland',
+
+  // Atlanta
+  'atlanta': 'Atlanta',
+  'atlanta, ga': 'Atlanta',
+
+  // Miami
+  'miami': 'Miami',
+  'miami, fl': 'Miami',
+  'miami beach': 'Miami',
+
+  // Dallas
+  'dallas': 'Dallas',
+  'dallas, tx': 'Dallas',
+
+  // Houston
+  'houston': 'Houston',
+  'houston, tx': 'Houston',
+
+  // Philadelphia
+  'philadelphia': 'Philadelphia',
+  'philadelphia, pa': 'Philadelphia',
+  'philly': 'Philadelphia',
+
+  // Phoenix
+  'phoenix': 'Phoenix',
+  'phoenix, az': 'Phoenix',
+
+  // San Diego
+  'san diego': 'San Diego',
+  'san diego, ca': 'San Diego',
+
+  // San Antonio
+  'san antonio': 'San Antonio',
+  'san antonio, tx': 'San Antonio',
+
+  // San Jose
+  'san jose': 'San Jose',
+  'san jose, ca': 'San Jose',
+
+  // Other US Cities
+  'columbus': 'Columbus',
+  'indianapolis': 'Indianapolis',
+  'charlotte': 'Charlotte',
+  'detroit': 'Detroit',
+  'nashville': 'Nashville',
+  'baltimore': 'Baltimore',
+  'milwaukee': 'Milwaukee',
+  'raleigh': 'Raleigh',
+  'minneapolis': 'Minneapolis',
+  'sacramento': 'Sacramento',
+  'kansas city': 'Kansas City',
+  'las vegas': 'Las Vegas',
+
+  // London
+  'london': 'London',
+  'london, uk': 'London',
+
+  // Berlin
+  'berlin': 'Berlin',
+  'berlin, germany': 'Berlin',
+
+  // Paris
+  'paris': 'Paris',
+  'paris, france': 'Paris',
+
+  // Amsterdam
+  'amsterdam': 'Amsterdam',
+  'amsterdam, netherlands': 'Amsterdam',
+
+  // Dublin
+  'dublin': 'Dublin',
+  'dublin, ireland': 'Dublin',
+
+  // Madrid
+  'madrid': 'Madrid',
+  'madrid, spain': 'Madrid',
+
+  // Barcelona
+  'barcelona': 'Barcelona',
+  'barcelona, spain': 'Barcelona',
+
+  // Munich
+  'munich': 'Munich',
+  'munich, germany': 'Munich',
+  'münchen': 'Munich',
+
+  // Stockholm
+  'stockholm': 'Stockholm',
+  'stockholm, sweden': 'Stockholm',
+
+  // Copenhagen
+  'copenhagen': 'Copenhagen',
+  'copenhagen, denmark': 'Copenhagen',
+
+  // Vienna
+  'vienna': 'Vienna',
+  'vienna, austria': 'Vienna',
+  'wien': 'Vienna',
+
+  // Rome
+  'rome': 'Rome',
+  'rome, italy': 'Rome',
+  'roma': 'Rome',
+
+  // Milan
+  'milan': 'Milan',
+  'milan, italy': 'Milan',
+  'milano': 'Milan',
+
+  // Warsaw
+  'warsaw': 'Warsaw',
+  'warsaw, poland': 'Warsaw',
+  'warszawa': 'Warsaw',
+
+  // Prague
+  'prague': 'Prague',
+  'prague, czech republic': 'Prague',
+  'praha': 'Prague',
+
+  // Brussels
+  'brussels': 'Brussels',
+  'brussels, belgium': 'Brussels',
+  'bruxelles': 'Brussels',
+
+  // Lisbon
+  'lisbon': 'Lisbon',
+  'lisbon, portugal': 'Lisbon',
+  'lisboa': 'Lisbon',
+
+  // Other EU cities
+  'hamburg': 'Hamburg',
+  'budapest': 'Budapest',
+  'athens': 'Athens',
+  'helsinki': 'Helsinki',
+  'oslo': 'Oslo',
+  'rotterdam': 'Rotterdam',
+  'frankfurt': 'Frankfurt',
+  'cologne': 'Cologne',
+  'stuttgart': 'Stuttgart',
+  'lyon': 'Lyon',
+  'marseille': 'Marseille',
+  'valencia': 'Valencia',
+}
+
+/**
+ * Invalid location markers to filter out
+ */
+const INVALID_LOCATIONS = [
+  'null', 'none', 'n/a', 'na', 'n.a.', 'unknown', 'tbd', 'to be determined',
+  'various', 'multiple', 'flexible', 'anywhere', 'worldwide', 'unspecified',
+  'not specified', '', ' ', 'multiple locations', 'varies'
+]
+
+/**
+ * Filter out invalid location values
+ */
+export function isValidLocation(location: string): boolean {
+  if (!location) return false
+
+  const lowerLoc = location.toLowerCase().trim()
+
+  // Exclude invalid markers
+  if (INVALID_LOCATIONS.includes(lowerLoc)) return false
+
+  // Exclude very short values (likely invalid)
+  if (lowerLoc.length < 2) return false
+
+  // Exclude numeric-only values
+  if (/^\d+$/.test(lowerLoc)) return false
+
+  // Exclude values that look like job titles
+  if (lowerLoc.includes('product manager') || lowerLoc.includes('engineer') || lowerLoc.includes('developer')) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Normalize location input to standardized city name
+ * Returns city name or null if cannot be normalized
+ */
+export function normalizeLocation(input: string): string | null {
+  if (!input || !isValidLocation(input)) return null
+
+  const normalized = input.toLowerCase().trim()
+
+  // Direct mapping
+  if (normalized in LOCATION_NORMALIZATION_MAP) {
+    return LOCATION_NORMALIZATION_MAP[normalized]
+  }
+
+  // Pattern matching for cities
+  // Check if input contains any of our known cities
+  const allCities = [...US_MAJOR_CITIES, ...EU_MAJOR_CITIES]
+
+  for (const city of allCities) {
+    const cityLower = city.toLowerCase()
+    if (normalized.includes(cityLower)) {
+      return city
+    }
+  }
+
+  // Check for metro area patterns
+  if (normalized.includes('san francisco') || normalized.includes('silicon valley') || normalized.includes('bay area')) {
+    return 'San Francisco'
+  }
+  if (normalized.includes('new york') || normalized.includes('nyc')) {
+    return 'New York'
+  }
+  if (normalized.includes('los angeles') || normalized.includes(' la ')) {
+    return 'Los Angeles'
+  }
+  if (normalized.includes('washington') && (normalized.includes('dc') || normalized.includes('d.c.'))) {
+    return 'Washington DC'
+  }
+
+  // Remote patterns
+  if (normalized.includes('remote')) {
+    return 'Remote'
+  }
+
+  return null // Cannot normalize
+}
+
+/**
+ * Get all valid normalized cities (for dropdown display)
+ */
+export function getAllNormalizedCities(): string[] {
+  const cities = new Set<string>()
+
+  // Add Remote first
+  cities.add('Remote')
+
+  // Add US cities
+  US_MAJOR_CITIES.forEach(city => cities.add(city))
+
+  // Add EU cities
+  EU_MAJOR_CITIES.forEach(city => cities.add(city))
+
+  return Array.from(cities).sort()
+}
+
+// ==================== WORK ARRANGEMENT (KEEP EXISTING - WORKING) ====================
+
+export function normalizeWorkArrangement(value: string): string | null {
+  if (!value) return null
+
+  const lowerValue = value.toLowerCase().trim()
+
+  const WORK_ARRANGEMENT_MAP: Record<string, 'Remote' | 'Hybrid' | 'In-Person' | null> = {
+    'remote': 'Remote',
+    'remote_us': 'Remote',
+    'remote_only': 'Remote',
+    'remote_first': 'Remote',
+    'remote_global': 'Remote',
+    'fully_remote': 'Remote',
+    'fully remote': 'Remote',
+    'work_from_home': 'Remote',
+    'work from home': 'Remote',
+    'wfh': 'Remote',
+    '100% remote': 'Remote',
+    'remote work': 'Remote',
+
+    'hybrid': 'Hybrid',
+    'hybrid_only': 'Hybrid',
+    'flexible': 'Hybrid',
+    'flexible_remote': 'Hybrid',
+    'part_remote': 'Hybrid',
+    'remote_hybrid': 'Hybrid',
+    'hybrid remote': 'Hybrid',
+    'flexible work': 'Hybrid',
+
+    'onsite': 'In-Person',
+    'on-site': 'In-Person',
+    'on site': 'In-Person',
+    'onsite_only': 'In-Person',
+    'office_first': 'In-Person',
+    'in-person': 'In-Person',
+    'in_office': 'In-Person',
+    'office': 'In-Person',
+  }
+
+  const mapped = WORK_ARRANGEMENT_MAP[lowerValue]
+  if (mapped !== undefined) return mapped
+
+  // Pattern matching
+  if (lowerValue.includes('remote') && !lowerValue.includes('hybrid')) return 'Remote'
+  if (lowerValue.includes('hybrid') || lowerValue.includes('flexible')) return 'Hybrid'
+  if (lowerValue.includes('onsite') || lowerValue.includes('office')) return 'In-Person'
+
+  return null
+}
+
+export function reverseFormatWorkArrangement(displayValue: string): string[] {
+  const reverseMap: Record<string, string[]> = {
+    'Remote': ['remote', 'remote_us', 'remote_only', 'remote_first', 'remote_global', 'fully_remote', 'wfh'],
+    'Hybrid': ['hybrid', 'hybrid_only', 'flexible', 'flexible_remote', 'part_remote'],
+    'In-Person': ['onsite', 'on-site', 'onsite_only', 'office_first', 'in-person', 'in_office', 'office']
+  }
+  return reverseMap[displayValue] || [displayValue.toLowerCase()]
+}
+
+// ==================== REVERSE MAPPING ====================
+
+export function reverseNormalizeSeniority(displayValue: PMSeniorityLevel): string[] {
+  // Find all keys that map to this display value
+  const keys: string[] = []
+  for (const [key, value] of Object.entries(SENIORITY_NORMALIZATION_MAP)) {
+    if (value === displayValue) {
+      keys.push(key)
+    }
+  }
+  return keys.length > 0 ? keys : [displayValue.toLowerCase()]
+}
+
+export function reverseNormalizeLocation(displayValue: string): string[] {
+  // Find all keys that map to this display value
+  const keys: string[] = []
+  for (const [key, value] of Object.entries(LOCATION_NORMALIZATION_MAP)) {
+    if (value === displayValue) {
+      keys.push(key)
+    }
+  }
+  return keys.length > 0 ? keys : [displayValue.toLowerCase()]
+}


### PR DESCRIPTION
…ties and PM seniority levels

This implements the user-requested approach for high-cardinality to low-cardinality normalization:

**Seniority Levels:**
- Reduces 60+ variations to 8 PM-specific levels
- Levels: Associate PM, PM, Senior PM, Lead PM, Staff PM, Director, VP, CPO
- Comprehensive mapping handles common variations (sr, principal, etc.)

**Locations:**
- Reduces 1000+ variations to 93 normalized cities
- 50 US major cities (500K+ population from US Census)
- 42 EU major cities (500K+ population from Eurostat)
- Filters out invalid values (null, n/a, unknown)

**Work Arrangement:**
- Kept as-is (user confirmed working correctly)
- 3 options: Remote, Hybrid, In-Person

**Technical Implementation:**
- Created filter-normalizers.ts with predefined mapping tables
- Array-based reverse mapping for accurate database queries
- Updated query logic to use .in() with multiple DB values
- All 72 normalization tests passing

**Cardinality Reduction:**
- Seniority: 87% reduction (60+ → 8)
- Locations: 91% reduction (1000+ → 93)
- Work Arrangement: 90% reduction (30+ → 3)

Files:
- NEW: src/lib/filter-normalizers.ts (700+ lines)
- NEW: src/lib/__tests__/filter-normalizers.test.ts (300+ lines)
- UPDATED: src/lib/filter-formatters.ts (delegates to normalizers)
- UPDATED: src/app/page.tsx (array-based query logic)
- UPDATED: src/app/api/search/route.ts (array-based filters)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved seniority, location, and work arrangement filters to provide more accurate and comprehensive search results
  * Enhanced filter logic to capture all relevant matching opportunities for each filter value

* **Tests**
  * Added comprehensive test coverage for filter normalization and validation across seniority, location, and work arrangement types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->